### PR TITLE
Added "artefact validate" command

### DIFF
--- a/repairbox/artefact.py
+++ b/repairbox/artefact.py
@@ -2,10 +2,12 @@ import os
 import yaml
 import docker
 import copy
+import textwrap
 import repairbox
 import repairbox.test
 
 from typing import List, Iterator, Dict
+from repairbox.util import print_task_start, print_task_end
 from repairbox.build import BuildInstructions
 from repairbox.container import Container
 from repairbox.test import TestSuite
@@ -207,31 +209,37 @@ class Artefact(object):
 
             # ensure we can compile the artefact
             # TODO: check compilation status!
-            print('Compiling...\t', end='')
+            print_task_start('Compiling')
             c.compile()
-            print('[OK?]')
+            print_task_end('Compiling', 'OK')
 
             if isinstance(self.harness, repairbox.test.GenProgTestSuite):
 
                 for t in self.harness.passing:
-                    print('Running test: {}...\t'.format(t.identifier), end='')
+                    task = 'Running test: {}'.format(t.identifier)
+                    print_task_start(task)
+
                     outcome = c.execute(t)
                     if not outcome.passed:
                         validated = False
-                        print('[UNEXPECTED: FAIL]')
-                        print(outcome.response.output)
+                        print_task_end(task, 'UNEXPECTED: FAIL')
+                        response = textwrap.indent(outcome.response.output, ' ' * 4)
+                        print('\n' + response)
                     else:
-                        print('[OK]')
+                        print_task_end(task, 'OK')
 
                 for t in self.harness.failing:
-                    print('Running test: {}...\t'.format(t.identifier), end='')
+                    task = 'Running test: {}'.format(t.identifier)
+                    print_task_start(task)
+
                     outcome = c.execute(t)
                     if outcome.passed:
                         validated = False
-                        print('[UNEXPECTED: PASS]')
-                        print(outcome.response.output)
+                        print_task_end(task, 'UNEXPECTED: PASS')
+                        response = textwrap.indent(outcome.response.output, ' ' * 4)
+                        print('\n' + response)
                     else:
-                        print('[OK]')
+                        print_task_end(task, 'OK')
 
         # ensure that the container is destroyed!
         finally:

--- a/repairbox/artefact.py
+++ b/repairbox/artefact.py
@@ -194,7 +194,7 @@ class Artefact(object):
         # attempt to rebuild -- don't worry, Docker's layer caching prevents us
         # from actually having to rebuild everything from scratch :-)
         try:
-            self.build(force=True)
+            self.build(quiet=True, force=True)
         except docker.errors.BuildError:
             print("failed to build artefact: {}".format(self.identifier))
             return False
@@ -213,11 +213,11 @@ class Artefact(object):
         return True
 
 
-    def build(self, force=False) -> None:
+    def build(self, quiet=False, force=False) -> None:
         """
         Builds the Docker image for this artefact.
         """
-        self.__build_instructions.build(force=force)
+        self.__build_instructions.build(quiet=quiet, force=force)
 
 
     def uninstall(self, force=False, noprune=False) -> None:

--- a/repairbox/artefact.py
+++ b/repairbox/artefact.py
@@ -205,21 +205,31 @@ class Artefact(object):
         try:
             c = self.provision()
 
+            # ensure we can compile the artefact
+            # TODO: check compilation status!
+            print('Compiling...\t', end='')
+            c.compile()
+            print('[OK?]')
+
             if isinstance(self.harness, repairbox.test.GenProgTestSuite):
 
                 for t in self.harness.passing:
                     print('Running test: {}...\t'.format(t.identifier), end='')
-                    if not c.execute(t).passed:
+                    outcome = c.execute(t)
+                    if not outcome.passed:
                         validated = False
                         print('[UNEXPECTED: FAIL]')
+                        print(outcome.response.output)
                     else:
                         print('[OK]')
 
                 for t in self.harness.failing:
                     print('Running test: {}...\t'.format(t.identifier), end='')
-                    if c.execute(t).passed:
+                    outcome = c.execute(t)
+                    if outcome.passed:
                         validated = False
                         print('[UNEXPECTED: PASS]')
+                        print(outcome.response.output)
                     else:
                         print('[OK]')
 

--- a/repairbox/artefact.py
+++ b/repairbox/artefact.py
@@ -179,10 +179,13 @@ class Artefact(object):
         return "{}:{}".format(self.__dataset.name, self.__name)
 
 
-    def validate(self) -> bool:
+    def validate(self, verbose: bool = True) -> bool:
         """
         Checks that this artefact successfully builds and that it produces an
         expected set of test suite outcomes.
+
+        :param verbose: toggles verbosity of output. If set to `True`, the
+            outcomes of each test suite will be printed to the standard output.
 
         :returns `True` if artefact builds and produces expected outcomes, else
             `False`.

--- a/repairbox/artefact.py
+++ b/repairbox/artefact.py
@@ -179,6 +179,37 @@ class Artefact(object):
         return "{}:{}".format(self.__dataset.name, self.__name)
 
 
+    def validate(self) -> bool:
+        """
+        Checks that this artefact successfully builds and that it produces an
+        expected set of test suite outcomes.
+
+        :returns `True` if artefact builds and produces expected outcomes, else
+            `False`.
+        """
+
+        # attempt to rebuild -- don't worry, Docker's layer caching prevents us
+        # from actually having to rebuild everything from scratch :-)
+        try:
+            self.build(force=True)
+        except docker.errors.BuildError:
+            print("failed to build artefact: {}".format(self.identifier))
+            return False
+
+        # provision a container
+        try:
+            c = self.provision()
+
+            # TODO: check test suite outcomes
+
+        # ensure that the container is destroyed!
+        finally:
+            if c:
+                c.destroy()
+
+        return True
+
+
     def build(self, force=False) -> None:
         """
         Builds the Docker image for this artefact.

--- a/repairbox/artefact.py
+++ b/repairbox/artefact.py
@@ -194,7 +194,7 @@ class Artefact(object):
         # attempt to rebuild -- don't worry, Docker's layer caching prevents us
         # from actually having to rebuild everything from scratch :-)
         try:
-            self.build(quiet=True, force=True)
+            self.build(force=True, quiet=True)
         except docker.errors.BuildError:
             print("failed to build artefact: {}".format(self.identifier))
             return False
@@ -213,11 +213,11 @@ class Artefact(object):
         return True
 
 
-    def build(self, quiet=False, force=False) -> None:
+    def build(self, force=False, quiet=False) -> None:
         """
         Builds the Docker image for this artefact.
         """
-        self.__build_instructions.build(quiet=quiet, force=force)
+        self.__build_instructions.build(force=force, quiet=quiet)
 
 
     def uninstall(self, force=False, noprune=False) -> None:

--- a/repairbox/build.py
+++ b/repairbox/build.py
@@ -187,12 +187,13 @@ class BuildInstructions(object):
         """
         if self.depends_on:
             dep = self.source.dependencies[self.depends_on]
-            dep.build(force=force)
+            dep.build(force=force, quiet=quiet)
 
         if self.installed and not force:
             return
 
-        print("Building image: {}".format(self.tag))
+        if not quiet:
+            print("Building image: {}".format(self.tag))
 
         tf = os.path.join(self.abs_context, '.Dockerfile')
         try:
@@ -212,6 +213,7 @@ class BuildInstructions(object):
 
                 # TODO: check build status!
 
-            print("Built image: {}".format(self.tag))
+            if not quiet:
+                print("Built image: {}".format(self.tag))
         finally:
             os.remove(tf)

--- a/repairbox/cli.py
+++ b/repairbox/cli.py
@@ -36,6 +36,17 @@ def update_sources(rbox: 'RepairBox', ) -> None:
     rbox.sources.update()
 
 
+###############################################################################
+# [artefact] group
+###############################################################################
+
+
+def validate_artefact(rbox: 'RepairBox', name: str, verbose: bool = True) -> None:
+    print('validating artefact: {}'.format(name))
+    artefact = rbox.artefacts[name]
+    artefact.validate(verbose=verbose)
+
+
 def install_artefact(rbox: 'RepairBox', name: str, update: bool) -> None:
     print('installing artefact: {}'.format(name))
     artefact = rbox.artefacts[name]
@@ -60,7 +71,6 @@ def upload_artefact(rbox: 'RepairBox', name: str) -> None:
     artefact.upload()
 
 
-# TODO: wrong name!
 def uninstall_artefact(rbox: 'RepairBox', name: str, force: bool) -> None:
     print('uninstalling artefact: {}'.format(name))
     artefact = rbox.artefacts[name]
@@ -276,6 +286,13 @@ def main():
     ###########################################################################
     g_artefact = subparsers.add_parser('artefact')
     g_subparsers = g_artefact.add_subparsers()
+
+    # [artefact validate (-v|--verbose) :artefact]
+    cmd = g_subparsers.add_parser('validate')
+    cmd.add_argument('artefact')
+    cmd.add_argument('-v', '--verbose',
+                     action='store_true')
+    cmd.set_defaults(func=lambda args: validate_artefact(rbox, args.artefact, args.verbose))
 
     # [artefact install (--update) :artefact]
     cmd = g_subparsers.add_parser('install')

--- a/repairbox/cli.py
+++ b/repairbox/cli.py
@@ -44,7 +44,10 @@ def update_sources(rbox: 'RepairBox', ) -> None:
 def validate_artefact(rbox: 'RepairBox', name: str, verbose: bool = True) -> None:
     print('validating artefact: {}'.format(name))
     artefact = rbox.artefacts[name]
-    artefact.validate(verbose=verbose)
+    if artefact.validate(verbose=verbose):
+        print('OK')
+    else:
+        print('FAIL')
 
 
 def install_artefact(rbox: 'RepairBox', name: str, update: bool) -> None:

--- a/repairbox/container.py
+++ b/repairbox/container.py
@@ -1,5 +1,6 @@
 import docker
 import copy
+import sys
 import os
 import subprocess
 import tempfile
@@ -79,7 +80,7 @@ class ExecResponse(object):
         """
         The output of the execution.
         """
-        return self.__output
+        return self.__output.decode(sys.stdout.encoding)
 
 
 class Container(object):

--- a/repairbox/test.py
+++ b/repairbox/test.py
@@ -1,5 +1,5 @@
 import typing
-from typing import List
+from typing import List, Iterator
 
 
 class TestCase(object):
@@ -171,12 +171,37 @@ class GenProgTestSuite(SimpleTestSuite):
         assert passing >= 0
         assert failing > 0
 
-        self.__passing = passing
-        self.__failing = failing
-
         tests = ["p{}".format(n) for n in range(1, passing + 1)] + \
                 ["n{}".format(n) for n in range(1, failing + 1)]
         super().__init__(command, context, time_limit, tests)
+
+        # extract the passing and failing test cases
+        self.__passing = []
+        self.__failing = []
+
+        for t in self.tests:
+            if t.identifier.startswith('p'):
+                self.__passing.append(t)
+            else:
+                self.__failing.append(t)
+
+
+    @property
+    def passing(self) -> Iterator[TestCase]:
+        """
+        The test cases that were passed by the original, unmodified artefact.
+        """
+        for t in self.__passing:
+            yield t
+
+
+    @property
+    def failing(self) -> Iterator[TestCase]:
+        """
+        The test cases that were failed by the original, unmodified artefact.
+        """
+        for t in self.__failing:
+            yield t
 
 
     @property
@@ -184,7 +209,7 @@ class GenProgTestSuite(SimpleTestSuite):
         """
         The number of passing tests in the test suite.
         """
-        return self.__passing
+        return len(self.__passing)
 
 
     @property
@@ -192,7 +217,7 @@ class GenProgTestSuite(SimpleTestSuite):
         """
         The number of failing tests in the test suite.
         """
-        return self.__failing
+        return len(self.__failing)
 
 
     @property

--- a/repairbox/util.py
+++ b/repairbox/util.py
@@ -1,1 +1,23 @@
+import sys
 
+
+def printflush(s: str, end: str = '\n') -> None:
+    """
+    Prints a given string to the standard output and immediately flushes.
+    """
+    print(s, end=end)
+    sys.stdout.flush()
+
+
+def print_task_start(task: str) -> None:
+    s = '{}...'.format(task)
+    printflush(s, end='\r')
+
+
+def print_task_end(task: str, outcome: str) -> None:
+    width = 80
+    outcome = '[{}]'.format(outcome)
+    left = '{}...'.format(task)
+    right = outcome.rjust(width - len(left), ' ')
+    s = left + right
+    printflush(s, end='\n')


### PR DESCRIPTION
Allows users to validate that an artefact can built as a Docker image, that the artefact compiles, and that, where appropriate, the test suite for the artefact produces the expected set of outcomes.

```
$ repairbox source add https://github.com/ChrisTimperley/RepairBox
$ repairbox artefact validate manybugs:python:69785-69789
validating artefact: manybugs:python:69785-69789
Compiling...	[OK?]
Running test: p1...	[OK]
Running test: p2...	[OK]
...
Running test: p238...	[UNEXPECTED: FAIL]

    basename: missing operand
    Try 'basename --help' for more information.
    ./test.sh: line 5: [: =: unary operator expected
    [1/1] test_socket
    test test_socket failed -- Traceback (most recent call last):
      File "/experiment/src/Lib/test/test_socket.py", line 1534, in test_create_connection
        self.assertEqual(cm.exception.errno, errno.ECONNREFUSED)
    AssertionError: 99 != 111

    1 test failed:
        test_socket
    FAIL: test_socket
    python: no process found

Running test: p239...	[OK]
Running test: p240...	[OK]
...
FAIL
```