### PR TITLE
Implemented a better fix to UID-related provisioning bug (fixes #131)

### DIFF
--- a/bugzoo/container.py
+++ b/bugzoo/container.py
@@ -64,10 +64,15 @@ class Container(object):
 
         # mount the environment file
         volumes[self.__env_file.name] = \
-            {'bind': '/.environment', 'mode': 'rw'}
+            {'bind': '/.environment.host', 'mode': 'ro'}
 
         # construct a Docker container for this bug
-        cmd = '/bin/bash -v -c "sudo chown $(whoami) /.environment && source /.environment && /bin/bash"'
+        cmd_cp = 'sudo cp /.enviromment.host /.environment'
+        cmd_chown = 'sudo chown $(whoami) /.environment'
+        cmd_source = 'source /.environment'
+        cmd = '/bin/bash -v -c "{} && {} && {} /bin/bash"'.format(cmd_cp,
+                                                                  cmd_chown,
+                                                                  cmd_source)
         client = docker.from_env() # nooooooooo
         self.__container = \
             client.containers.create(bug.image,

--- a/bugzoo/container.py
+++ b/bugzoo/container.py
@@ -67,10 +67,10 @@ class Container(object):
             {'bind': '/.environment.host', 'mode': 'ro'}
 
         # construct a Docker container for this bug
-        cmd_cp = 'sudo cp /.enviromment.host /.environment'
+        cmd_cp = 'sudo cp /.environment.host /.environment'
         cmd_chown = 'sudo chown $(whoami) /.environment'
         cmd_source = 'source /.environment'
-        cmd = '/bin/bash -v -c "{} && {} && {} /bin/bash"'.format(cmd_cp,
+        cmd = '/bin/bash -v -c "{} && {} && {} && /bin/bash"'.format(cmd_cp,
                                                                   cmd_chown,
                                                                   cmd_source)
         client = docker.from_env() # nooooooooo


### PR DESCRIPTION
Better fix for #131. Avoids changing UID of temporary file, thus allowing it to be destroyed by the host machine without the need to change its permissions before destroying the container.