### PR TITLE
Added support for containers with custom entrypoints

### DIFF
--- a/bugzoo/compiler/__init__.py
+++ b/bugzoo/compiler/__init__.py
@@ -185,9 +185,11 @@ class CatkinCompiler(SimpleCompiler):
                  time_limit: float
                  ) -> None:
         cmd = 'catkin build'
-        cmdi = 'exit 1'
+        cmdi = \
+            ('catkin config --cmake-args '
+             '-DCMAKE_CXX_FLAGS="--coverage" -DCMAKE_LD_FLAGS="--coverage"')
         super().__init__(command=cmd,
-                         command_clean='catkin clean',
+                         command_clean='catkin clean -y',
                          command_with_instrumentation=cmdi,
                          context=workspace,
                          time_limit=time_limit)

--- a/bugzoo/core/fileline.py
+++ b/bugzoo/core/fileline.py
@@ -1,4 +1,5 @@
-from typing import Dict, List, Set, Iterator, Iterable, Any, FrozenSet
+from typing import  Dict, List, Set, Iterator, Iterable, Any, FrozenSet, \
+                    Callable
 
 
 class FileLine(object):
@@ -141,6 +142,16 @@ class FileLineSet(object):
         """
         return file_line.filename in self.__contents and \
                file_line.num in self.__contents[file_line.filename]
+
+    def filter(self,
+               predicate: Callable[[FileLine], 'FileLineSet']
+               ) -> 'FileLineSet':
+        """
+        Returns a subset of the file lines within this set that satisfy a given
+        filtering criterion.
+        """
+        filtered = [fileline for fileline in self if predicate(fileline)]
+        return FileLineSet.from_list(filtered)
 
     def union(self, other: 'FileLineSet') -> 'FileLineSet':
         """

--- a/bugzoo/mgr/container.py
+++ b/bugzoo/mgr/container.py
@@ -132,7 +132,6 @@ class ContainerManager(object):
         # all future calls to the container will source the variables in
         # /.environment.
         cmd = (
-            "echo $(whoami) && "
             "sudo cp /.environment.host /.environment && "
             "sudo chown $(whoami):$(whoami) /.environment && "
             "source /.environment && "

--- a/bugzoo/mgr/container.py
+++ b/bugzoo/mgr/container.py
@@ -160,7 +160,6 @@ class ContainerManager(object):
         # block until /.environment is ready
         for output in dockerc.logs(stream=True):
             output = output.strip().decode('utf-8')
-            print("'{}'".format(output))
             if output == "BUGZOO IS READY TO GO!":
                 break
 

--- a/bugzoo/mgr/container.py
+++ b/bugzoo/mgr/container.py
@@ -137,7 +137,7 @@ class ContainerManager(object):
             "sudo chown $(whoami):$(whoami) /.environment && "
             "source /.environment && "
             "sudo rm /.environment && "
-            "export | sudo tee /.environment && "
+            "export | sudo tee /.environment > /dev/null && "
             "sudo chmod 444 /.environment && "
             "/bin/bash"
         )

--- a/bugzoo/mgr/container.py
+++ b/bugzoo/mgr/container.py
@@ -138,6 +138,7 @@ class ContainerManager(object):
             "sudo rm /.environment && "
             "export | sudo tee /.environment > /dev/null && "
             "sudo chmod 444 /.environment && "
+            "echo 'BUGZOO IS READY TO GO!' && "
             "/bin/bash"
         )
         cmd = '/bin/bash -c "{}"'.format(cmd)
@@ -155,6 +156,13 @@ class ContainerManager(object):
                                                    detach=True)
         self.__dockerc[uid] = dockerc
         dockerc.start()
+
+        # block until /.environment is ready
+        for output in dockerc.logs(stream=True):
+            output = output.strip().decode('utf-8')
+            print("'{}'".format(output))
+            if output == "BUGZOO IS READY TO GO!":
+                break
 
         container = Container(bug=bug,
                               uid=uid,


### PR DESCRIPTION
Since `docker exec` uses `/bin/bash` rather than the entrypoint for a given container, `docker exec` commands aren't guaranteed to be executed in a shell with the correct environmental variables. To address the issue, the container initialisation method now dumps the state of the initialised environment to a read-only file, `/.environment`, which is (automatically) sourced at the start of each `docker exec` call.