### PR TITLE
Use backslashreplace when decoding command output (fixes #336)

### DIFF
--- a/bugzoo/mgr/container.py
+++ b/bugzoo/mgr/container.py
@@ -576,7 +576,7 @@ class ContainerManager(object):
 
         output = []
         for line in out:
-            line = line.decode('utf-8',"backslashreplace").rstrip('\n')
+            line = line.decode('utf-8', 'backslashreplace').rstrip('\n')
             if verbose:
                 print(line, flush=True)
             output.append(line)

--- a/bugzoo/mgr/container.py
+++ b/bugzoo/mgr/container.py
@@ -576,7 +576,7 @@ class ContainerManager(object):
 
         output = []
         for line in out:
-            line = line.decode('utf-8').rstrip('\n')
+            line = line.decode('utf-8',"backslashreplace").rstrip('\n')
             if verbose:
                 print(line, flush=True)
             output.append(line)


### PR DESCRIPTION
Adding "backslashreplace" to 'utf-8' decoding of container I/O to avoid getting UnicodeDecodeError when processing byte literals for testing infrastructure for BugZoo issue #336 

Not sure this is a perfect one-size-fits-all solution, but worked for my situation.