### PR TITLE
bug fix: added missing return to read_coverage

### DIFF
--- a/bugzoo/mgr/container.py
+++ b/bugzoo/mgr/container.py
@@ -359,7 +359,7 @@ class ContainerManager(object):
         self.coverage_extractor(container).cleanup()
 
     def read_coverage(self, container: Container) -> FileLineSet:
-        self.coverage_extractor(container).extract()
+        return self.coverage_extractor(container).extract()
 
     def coverage(self,
                  container: Container,


### PR DESCRIPTION
The output of `coverage_extractor` was being lost.